### PR TITLE
update TestData to use string slice

### DIFF
--- a/Rust/src/lib.rs
+++ b/Rust/src/lib.rs
@@ -61,16 +61,16 @@ fn base_speed() -> f32 {
 mod tests {
     use super::*;
 
-    pub struct TestData<'a> {
-        pub name: String,
-            input: Parrot<'a>,
+    pub struct TestData<'a, 'b> {
+        pub name: &'b str,
+        input: Parrot<'a>,
         pub expected: f32,
     }
 
-    impl TestData<'_> {
-        pub fn new(name: impl Into<String>, input: Parrot, expected: f32) -> TestData {
+    impl<'a, 'b> TestData<'a, 'b> {
+        pub fn new(name: &'b str, input: Parrot<'a>, expected: f32) -> TestData<'a, 'b> {
             TestData {
-                name: name.into(),
+                name: name,
                 input,
                 expected,
             }


### PR DESCRIPTION
Worked out how to get the TestData type to use string slices by using multiple lifetimes.